### PR TITLE
Modify get fallback func

### DIFF
--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -826,7 +826,11 @@ cleanup:
 
 #else
 
-static void add_font_set(IDWriteFontSet *fontSet, ASS_FontProvider *provider)
+static void add_font_set(IDWriteFontSet *fontSet, ASS_FontProvider *provider,
+                         ASS_FontProviderMetaData requested_font,
+                         ASS_FontInfo **best_font_info, unsigned *best_font_score,
+                         bool match_extended_family, unsigned bold, unsigned italic,
+                         uint32_t code)
 {
     UINT32 n = IDWriteFontSet_GetFontCount(fontSet);
     for (UINT32 i = 0; i < n; i++) {
@@ -850,7 +854,9 @@ static void add_font_set(IDWriteFontSet *fontSet, ASS_FontProvider *provider)
         if (FAILED(hr) || !face)
             goto cleanup;
 
-        add_font_face((IDWriteFontFace *) face, provider, NULL, NULL);
+        add_font_face((IDWriteFontFace *) face, provider, NULL, NULL,
+                      requested_font, best_font_info, best_font_score,
+                      match_extended_family, bold, italic, code);
 
 cleanup:
         IDWriteFontFaceReference_Release(faceRef);
@@ -987,8 +993,9 @@ static ASS_FontInfo* match_fonts(void *priv, ASS_Library *lib,
         hr = IDWriteFactory3_GetSystemFontSet(factory3, &fontSet);
         IDWriteFactory3_Release(factory3);
         if (FAILED(hr) || !fontSet)
-            return;
+            return NULL;
 
+        unsigned best_font_score = UINT_MAX;
         DWRITE_FONT_PROPERTY_ID property_ids[] = {
             DWRITE_FONT_PROPERTY_ID_WIN32_FAMILY_NAME,
             DWRITE_FONT_PROPERTY_ID_FULL_NAME,
@@ -1007,7 +1014,9 @@ static ASS_FontInfo* match_fonts(void *priv, ASS_Library *lib,
             if (FAILED(hr) || !filteredSet)
                 continue;
 
-            add_font_set(filteredSet, provider);
+            add_font_set(filteredSet, provider, requested_font,
+                         &font_result, &best_font_score,
+                         match_extended_family, bold, italic, code);
 
             IDWriteFontSet_Release(filteredSet);
         }

--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -864,7 +864,12 @@ cleanup:
 }
 
 static void add_font(IDWriteFont *font, IDWriteFontFamily *fontFamily,
-                     ASS_FontProvider *provider)
+                     ASS_FontProvider *provider,
+                     ASS_FontProviderMetaData requested_font,
+                     ASS_FontInfo **best_font_info, unsigned *best_font_score,
+                     bool match_extended_family,
+                     unsigned bold, unsigned italic,
+                     uint32_t code)
 {
     ASS_FontProviderMetaData meta = {0};
     if (!get_font_info_IDWriteFont(font, fontFamily, &meta))
@@ -876,7 +881,9 @@ static void add_font(IDWriteFont *font, IDWriteFontFamily *fontFamily,
     font_priv->font = font;
     font = NULL;
 
-    ass_font_provider_add_font(provider, &meta, NULL, 0, font_priv);
+    update_best_matching_font(provider, &meta, font_priv, requested_font,
+                              best_font_info, best_font_score, match_extended_family,
+                              bold, italic, code);
 
 cleanup:
     free(meta.postscript_name);
@@ -1046,14 +1053,15 @@ static ASS_FontInfo* match_fonts(void *priv, ASS_Library *lib,
         hr = IDWriteGdiInterop_CreateFontFromLOGFONT(provider_priv->gdi_interop,
                                                      &lf, &font);
         if (FAILED(hr) || !font)
-            return;
+            return NULL;
 
         IDWriteFontFamily *fontFamily = NULL;
         hr = IDWriteFont_GetFontFamily(font, &fontFamily);
         IDWriteFont_Release(font);
         if (FAILED(hr) || !fontFamily)
-            return;
+            return NULL;
 
+        unsigned best_font_score = UINT_MAX;
         UINT32 n = IDWriteFontFamily_GetFontCount(fontFamily);
         for (UINT32 i = 0; i < n; i++) {
             hr = IDWriteFontFamily_GetFont(fontFamily, i, &font);
@@ -1067,7 +1075,9 @@ static ASS_FontInfo* match_fonts(void *priv, ASS_Library *lib,
                 continue;
             }
 
-            add_font(font, fontFamily, provider);
+            add_font(font, fontFamily, provider, requested_font,
+                     &font_result, &best_font_score,
+                     match_extended_family, bold, italic, code);
         }
 
         IDWriteFontFamily_Release(fontFamily);

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -209,7 +209,13 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
             meta.postscript_name = NULL;
 
         FcPatternReference(pat);
-        ass_font_provider_add_font(provider, &meta, path, index, (void *)pat);
+
+        ASS_FontInfo* font_info = ass_font_provider_get_font_info(provider, &meta, path, index, (void *)pat);
+        if (font_info) {
+            ass_font_provider_add_font(provider, font_info);
+            free(font_info);
+        }
+
     }
 
     FcFontSetDestroy(fonts);

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -212,7 +212,7 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
 
         ASS_FontInfo* font_info = ass_font_provider_get_font_info(provider, &meta, path, index, (void *)pat);
         if (font_info) {
-            ass_font_provider_add_font(provider, font_info);
+            ass_font_provider_add_font(provider, font_info, true);
             free(font_info);
         }
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -910,12 +910,17 @@ static char *select_font(ASS_FontSelector *priv,
         // TODO: consider changing the API to make more efficient
         // implementations possible.
         for (int i = 0; i < meta.n_fullname; i++) {
-            default_provider->funcs.match_fonts(default_provider->priv,
+            matched_font = default_provider->funcs.match_fonts(default_provider->priv,
                                                 priv->library, default_provider,
-                                                meta.fullnames[i]);
+                                                meta.fullnames[i], match_extended_family,
+                                                bold, italic, code);
+            // TODO - This might be a bad idea because
+            // we may not get the best font if meta.n_fullname > 1
+            // Currently, only fontconfig can have a meta.n_fullname > 1,
+            // but since it doesn't define match_fonts, we don't have the problem
+            if (!matched_font)
+                break;
         }
-        matched_font = find_font(priv, meta, match_extended_family,
-                                 bold, italic, code, &name_match);
     }
 
     result = get_font_result(matched_font, index, postscript_name, uid, stream);

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -94,10 +94,10 @@ struct font_selector {
     char *path_default;
     int index_default;
 
-    // font database
-    int n_font;
-    int alloc_font;
-    ASS_FontInfo *font_infos;
+    // embedded font database
+    int embedded_n_font;
+    int embedded_alloc_font;
+    ASS_FontInfo *embedded_font_infos;
 
     ASS_FontProvider *default_provider;
     ASS_FontProvider *embedded_provider;
@@ -395,15 +395,15 @@ ass_font_provider_add_font(ASS_FontProvider *provider,
     ASS_FontSelector *selector = provider->parent;
 
     // check size
-    if (selector->n_font >= selector->alloc_font) {
-        selector->alloc_font = FFMAX(1, 2 * selector->alloc_font);
-        selector->font_infos = realloc(selector->font_infos,
-                selector->alloc_font * sizeof(ASS_FontInfo));
+    if (selector->embedded_n_font >= selector->embedded_alloc_font) {
+        selector->embedded_alloc_font = FFMAX(1, 2 * selector->embedded_alloc_font);
+        selector->embedded_font_infos = realloc(selector->embedded_font_infos,
+                selector->embedded_alloc_font * sizeof(ASS_FontInfo));
     }
 
-    ASS_FontInfo* new_font_info = selector->font_infos + selector->n_font;
+    ASS_FontInfo* new_font_info = selector->embedded_font_infos + selector->embedded_n_font;
     *new_font_info = *info;
-    selector->n_font++;
+    selector->embedded_n_font++;
 }
 
 /**
@@ -565,21 +565,21 @@ static void ass_fontselect_cleanup(ASS_FontSelector *selector)
 {
     int i, w;
 
-    for (i = 0, w = 0; i < selector->n_font; i++) {
-        ASS_FontInfo *info = selector->font_infos + i;
+    for (i = 0, w = 0; i < selector->embedded_n_font; i++) {
+        ASS_FontInfo *info = selector->embedded_font_infos + i;
 
         // update write pointer
         if (info->provider != NULL) {
             // rewrite, if needed
             if (w != i)
-                memcpy(selector->font_infos + w, selector->font_infos + i,
+                memcpy(selector->embedded_font_infos + w, selector->embedded_font_infos + i,
                         sizeof(ASS_FontInfo));
             w++;
         }
 
     }
 
-    selector->n_font = w;
+    selector->embedded_n_font = w;
 }
 
 void ass_font_provider_free(ASS_FontProvider *provider)
@@ -588,8 +588,8 @@ void ass_font_provider_free(ASS_FontProvider *provider)
     ASS_FontSelector *selector = provider->parent;
 
     // free all fonts and mark their entries
-    for (i = 0; i < selector->n_font; i++) {
-        ASS_FontInfo *info = selector->font_infos + i;
+    for (i = 0; i < selector->embedded_n_font; i++) {
+        ASS_FontInfo *info = selector->embedded_font_infos + i;
 
         if (info->provider == provider) {
             ass_font_provider_free_fontinfo(info);
@@ -822,12 +822,12 @@ find_font(ASS_FontSelector *priv,
     ASS_FontInfo *selected = NULL;
 
     // do we actually have any fonts?
-    if (!priv->n_font)
+    if (!priv->embedded_n_font)
         return NULL;
 
     unsigned score_min = UINT_MAX;
-    for (int x = 0; x < priv->n_font; x++) {
-        ASS_FontInfo *font = &priv->font_infos[x];
+    for (int x = 0; x < priv->embedded_n_font; x++) {
+        ASS_FontInfo *font = &priv->embedded_font_infos[x];
         if (ass_update_best_matching_font(font, meta, match_extended_family, bold, italic, code, name_match, &score_min)) {
             selected = font;
         }
@@ -1245,7 +1245,7 @@ void ass_fontselect_free(ASS_FontSelector *priv)
     if (priv->embedded_provider)
         ass_font_provider_free(priv->embedded_provider);
 
-    free(priv->font_infos);
+    free(priv->embedded_font_infos);
     free(priv->path_default);
     free(priv->family_default);
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -1033,12 +1033,12 @@ char *ass_font_select(ASS_FontSelector *priv,
         const char *search_family = family;
         if (!search_family || !*search_family)
             search_family = "Arial";
-        char *fallback_family = default_provider->funcs.get_fallback(
-                default_provider->priv, priv->library, search_family, code);
+        ASS_FontInfo *fallback_family = default_provider->funcs.get_fallback(
+                default_provider->priv, priv->library, default_provider, search_family, bold, italic, code);
 
         if (fallback_family) {
-            res = select_font(priv, fallback_family, true, bold, italic,
-                    index, postscript_name, uid, data, code);
+            ass_font_provider_add_font(default_provider, fallback_family, false);
+            res = get_font_result(fallback_family, index, postscript_name, uid, data);
             free(fallback_family);
         }
     }

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -215,7 +215,7 @@ ass_font_provider_new(ASS_FontSelector *selector, ASS_FontProviderFuncs *funcs,
  *
  * \param info FontInfo struct to free associated data from
  */
-static void ass_font_provider_free_fontinfo(ASS_FontInfo *info)
+void ass_font_provider_free_fontinfo(ASS_FontInfo *info)
 {
     int j;
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -722,75 +722,117 @@ static bool check_glyph(ASS_FontInfo *fi, uint32_t code)
     return provider->funcs.check_glyph(fi->priv, code);
 }
 
-static char *
-find_font(ASS_FontSelector *priv,
-          ASS_FontProviderMetaData meta, bool match_extended_family,
+/**
+ * \brief Check if a font matches the given criteria.
+ * \param font The font to check.
+ * \param meta The requested font metadata used for comparison. Only the
+ *             `fullnames` and `n_fullname` fields are considered for matching.
+ * \param match_extended_family If true, the function allows matching against
+ *                              extended family names as defined by the provider.
+ *                              This behavior is provider-dependent.
+ * \param bold The requested boldness level.
+ * \param italic The requested italic style.
+ * \param name_match Set to true if the font matches the metadata,
+ *                   otherwise set to false.
+ * \param score Score representing the match. The lower, the better.
+ */
+static void
+is_font_match(ASS_FontInfo *font, ASS_FontProviderMetaData meta,
+          bool match_extended_family,
           unsigned bold, unsigned italic,
-          int *index, char **postscript_name, int *uid, ASS_FontStream *stream,
-          uint32_t code, bool *name_match)
+          bool *name_match, unsigned *score)
 {
     ASS_FontInfo req = {0};
-    ASS_FontInfo *selected = NULL;
-
-    // do we actually have any fonts?
-    if (!priv->n_font)
-        return NULL;
 
     // fill font request
     req.style_flags = (italic ? FT_STYLE_FLAG_ITALIC : 0);
     req.weight      = bold;
 
     // Match font family name against font list
-    unsigned score_min = UINT_MAX;
+    *score = UINT_MAX;
     for (int i = 0; i < meta.n_fullname; i++) {
         const char *fullname = meta.fullnames[i];
 
-        for (int x = 0; x < priv->n_font; x++) {
-            ASS_FontInfo *font = &priv->font_infos[x];
-            unsigned score = UINT_MAX;
+        if (matches_family_name(font, fullname, match_extended_family)) {
+            // If there's a family match, compare font attributes
+            // to determine best match in that particular family
+            *score = font_attributes_similarity(font, &req);
+            *name_match = true;
+            break;
+        } else if (matches_full_or_postscript_name(font, fullname)) {
+            // If we don't have any match, compare fullnames against request
+            // if there is a match now, assign lowest score possible. This means
+            // the font should be chosen instantly, without further search.
+            *score = 0;
+            *name_match = true;
+            break;
+        }
+    }
+}
 
-            if (matches_family_name(font, fullname, match_extended_family)) {
-                // If there's a family match, compare font attributes
-                // to determine best match in that particular family
-                score = font_attributes_similarity(font, &req);
-                *name_match = true;
-            } else if (matches_full_or_postscript_name(font, fullname)) {
-                // If we don't have any match, compare fullnames against request
-                // if there is a match now, assign lowest score possible. This means
-                // the font should be chosen instantly, without further search.
-                score = 0;
-                *name_match = true;
-            }
+bool ass_update_best_matching_font(ASS_FontInfo *info,
+                                   ASS_FontProviderMetaData requested_font,
+                                   bool match_extended_family,
+                                   unsigned bold, unsigned italic,
+                                   uint32_t code, bool *name_match,
+                                   unsigned *best_font_score)
+{
+    if (!info)
+        return false;
 
-            // Consider updating idx if score is better than current minimum
-            if (score < score_min) {
-                // Check if the font has the requested glyph.
-                // We are doing this here, for every font face, because
-                // coverage might differ between the variants of a font
-                // family. In practice, it is common that the regular
-                // style has the best coverage while bold/italic/etc
-                // variants cover less (e.g. FreeSans family).
-                // We want to be able to match even if the closest variant
-                // does not have the requested glyph, but another member
-                // of the family has the glyph.
-                if (!check_glyph(font, code))
-                    continue;
+    unsigned score = UINT_MAX;
+    is_font_match(info, requested_font, match_extended_family, bold, italic, name_match, &score);
 
-                score_min = score;
-                selected = font;
-            }
+    if (score < *best_font_score) {
+        // Check if the font has the requested glyph.
+        // We are doing this here, for every font face, because
+        // coverage might differ between the variants of a font
+        // family. In practice, it is common that the regular
+        // style has the best coverage while bold/italic/etc
+        // variants cover less (e.g. FreeSans family).
+        // We want to be able to match even if the closest variant
+        // does not have the requested glyph, but another member
+        // of the family has the glyph.
+        if (check_glyph(info, code)) {
+            *best_font_score = score;
+            return true;
+        }
+    }
 
-            // Lowest possible score instantly matches; this is typical
-            // for fullname matches, but can also occur with family matches.
-            if (score == 0)
-                break;
+    return false;
+}
+
+static ASS_FontInfo *
+find_font(ASS_FontSelector *priv,
+          ASS_FontProviderMetaData meta, bool match_extended_family,
+          unsigned bold, unsigned italic,
+          uint32_t code, bool *name_match)
+{
+    ASS_FontInfo *selected = NULL;
+
+    // do we actually have any fonts?
+    if (!priv->n_font)
+        return NULL;
+
+    unsigned score_min = UINT_MAX;
+    for (int x = 0; x < priv->n_font; x++) {
+        ASS_FontInfo *font = &priv->font_infos[x];
+        if (ass_update_best_matching_font(font, meta, match_extended_family, bold, italic, code, name_match, &score_min)) {
+            selected = font;
         }
 
-        // The list of names is sorted by priority. If we matched anything,
-        // we can and should stop.
-        if (selected != NULL)
+        // Lowest possible score instantly matches; this is typical
+        // for fullname matches, but can also occur with family matches.
+        if (score_min == 0)
             break;
     }
+
+    return selected;
+}
+
+static char *
+get_font_result(ASS_FontInfo *selected, int *index, char **postscript_name, int *uid, ASS_FontStream *stream)
+{
 
     // found anything?
     char *result = NULL;
@@ -834,6 +876,7 @@ static char *select_font(ASS_FontSelector *priv,
 {
     ASS_FontProvider *default_provider = priv->default_provider;
     ASS_FontProviderMetaData meta = {0};
+    ASS_FontInfo *matched_font = NULL;
     char *result = NULL;
     bool name_match = false;
 
@@ -856,9 +899,8 @@ static char *select_font(ASS_FontSelector *priv,
         meta = default_meta;
     }
 
-    result = find_font(priv, meta, match_extended_family,
-                       bold, italic, index, postscript_name, uid,
-                       stream, code, &name_match);
+    matched_font = find_font(priv, meta, match_extended_family,
+                             bold, italic, code, &name_match);
 
     // If no matching font was found, it might not exist in the font list
     // yet. Call the match_fonts callback to fill in the missing fonts
@@ -872,10 +914,11 @@ static char *select_font(ASS_FontSelector *priv,
                                                 priv->library, default_provider,
                                                 meta.fullnames[i]);
         }
-        result = find_font(priv, meta, match_extended_family,
-                           bold, italic, index, postscript_name, uid,
-                           stream, code, &name_match);
+        matched_font = find_font(priv, meta, match_extended_family,
+                                 bold, italic, code, &name_match);
     }
+
+    result = get_font_result(matched_font, index, postscript_name, uid, stream);
 
     // cleanup
     if (meta.fullnames != default_meta.fullnames) {

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -242,6 +242,17 @@ void ass_font_provider_free_fontinfo(ASS_FontInfo *info)
 }
 
 /**
+ * Free the private data associated with a FontInfo struct.
+ *
+ * \param info FontInfo struct to free private data from.
+ */
+void ass_font_provider_destroy_private_fontinfo(ASS_FontInfo *info)
+{
+    if (info->provider)
+        info->provider->funcs.destroy_font(info->priv);
+}
+
+/**
  * \brief Read basic metadata (names, weight, slant) from a FreeType face,
  * as required for the FontSelector for matching and sorting.
  * \param lib FreeType library

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -373,21 +373,49 @@ static void free_font_info(ASS_FontProviderMetaData *meta)
 /**
  * \brief Add a font to a font provider.
  * \param provider the font provider
- * \param meta basic metadata of the font
- * \param path path to the font file, or NULL
- * \param index face index inside the file (-1 to look up by PostScript name)
- * \param data private data for the font
- * \return success
+ * \param info The font to add to the database.
+ * \note After calling this function, **do not** call `ass_font_provider_free_fontinfo`
+ *       on the `info` parameter, as its contents have been copied.
  */
-bool
+void
 ass_font_provider_add_font(ASS_FontProvider *provider,
-                           ASS_FontProviderMetaData *meta, const char *path,
-                           int index, void *data)
+                           ASS_FontInfo* info)
+{
+    ASS_FontSelector *selector = provider->parent;
+
+    // check size
+    if (selector->n_font >= selector->alloc_font) {
+        selector->alloc_font = FFMAX(1, 2 * selector->alloc_font);
+        selector->font_infos = realloc(selector->font_infos,
+                selector->alloc_font * sizeof(ASS_FontInfo));
+    }
+
+    ASS_FontInfo* new_font_info = selector->font_infos + selector->n_font;
+    *new_font_info = *info;
+    selector->n_font++;
+}
+
+/**
+ * \brief Get the font info from a provider's font.
+ * \param provider the font provider
+ * \param meta the font metadata. See struct definition for more information.
+ * \param path absolute path to font, or NULL for memory-based fonts
+ * \param index index inside a font collection file
+ *              (-1 to look up by PostScript name)
+ * \param data private data for font callbacks
+ * \return A pointer to an ASS_FontInfo corresponding to the given parameters.
+ */
+ASS_FontInfo *
+ass_font_provider_get_font_info(ASS_FontProvider *provider,
+                                ASS_FontProviderMetaData *meta, const char *path,
+                                int index, void *data)
 {
     int i;
     ASS_FontSelector *selector = provider->parent;
-    ASS_FontInfo *info = NULL;
     ASS_FontProviderMetaData implicit_meta = {0};
+    ASS_FontInfo *info = calloc(1, sizeof(ASS_FontInfo));
+    if (!info)
+        goto error;
 
     if (!meta->n_family) {
         FT_Face face;
@@ -446,17 +474,6 @@ ass_font_provider_add_font(ASS_FontProvider *provider,
     printf("  index: %d\n", index);
 #endif
 
-    // check size
-    if (selector->n_font >= selector->alloc_font) {
-        selector->alloc_font = FFMAX(1, 2 * selector->alloc_font);
-        selector->font_infos = realloc(selector->font_infos,
-                selector->alloc_font * sizeof(ASS_FontInfo));
-    }
-
-    // copy over metadata
-    info = selector->font_infos + selector->n_font;
-    memset(info, 0, sizeof(ASS_FontInfo));
-
     // set uid
     info->uid = selector->uid++;
 
@@ -510,22 +527,22 @@ ass_font_provider_add_font(ASS_FontProvider *provider,
     info->priv  = data;
     info->provider = provider;
 
-    selector->n_font++;
-
     free_font_info(&implicit_meta);
     free(implicit_meta.postscript_name);
 
-    return true;
+    return info;
 
 error:
-    if (info)
+    if (info) {
         ass_font_provider_free_fontinfo(info);
+        free(info);
+    }
 
     free_font_info(&implicit_meta);
     free(implicit_meta.postscript_name);
     provider->funcs.destroy_font(data);
 
-    return false;
+    return NULL;
 }
 
 /**
@@ -997,11 +1014,15 @@ static void process_fontdata(ASS_FontProvider *priv, int idx)
         ft->face = face;
         ft->idx  = idx;
 
-        if (!ass_font_provider_add_font(priv, &info, NULL, face_index, ft)) {
+        ASS_FontInfo* font_info = ass_font_provider_get_font_info(priv, &info, NULL, face_index, ft);
+        if (!font_info) {
             ass_msg(library, MSGL_WARN, "Failed to add embedded font '%s'",
                     name);
             free(ft);
         }
+
+        ass_font_provider_add_font(priv, font_info);
+        free(font_info);
 
         free_font_info(&info);
     }

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -339,6 +339,13 @@ bool ass_update_best_matching_font(ASS_FontInfo *info,
 void ass_font_provider_free_fontinfo(ASS_FontInfo *info);
 
 /**
+ * Free the private data associated with a FontInfo struct.
+ *
+ * \param info FontInfo struct to free private data from.
+ */
+void ass_font_provider_destroy_private_fontinfo(ASS_FontInfo *info);
+
+/**
  * \brief Free font provider and associated fonts.
  * \param provider the font provider
  *

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -331,6 +331,14 @@ bool ass_update_best_matching_font(ASS_FontInfo *info,
     unsigned *best_font_score);
 
 /**
+ * Free all data associated with a FontInfo struct. Handles FontInfo structs
+ * with incomplete allocations well.
+ *
+ * \param info FontInfo struct to free associated data from
+ */
+void ass_font_provider_free_fontinfo(ASS_FontInfo *info);
+
+/**
  * \brief Free font provider and associated fonts.
  * \param provider the font provider
  *

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -296,6 +296,31 @@ ass_font_provider_get_font_info(ASS_FontProvider *provider,
                                 int index, void *data);
 
 /**
+ * \brief Updates the best matching font based on the given criteria.
+ * \param info The font to be evaluated.
+ * \param requested_font The requested font metadata used for comparison. Only the
+ *             `fullnames` and `n_fullname` fields are considered for matching.
+ * \param match_extended_family If true, the function allows matching against
+ *                              extended family names as defined by the provider.
+ *                              This behavior is provider-dependent.
+ * \param bold The requested boldness level.
+ * \param italic The requested italic style.
+ * \param code The character that should be present in the font, can be 0.
+ * \param name_match Set to true if the font matches the metadata,
+ *                   otherwise set to false.
+ * \param best_font_score Score representing the match. The lower, the better.
+ *                        It will be updated if the font has a better score.
+ * \return True if `info` provides a better match than the previously recorded
+ *         best font score. Otherwise, false.
+ */
+bool ass_update_best_matching_font(ASS_FontInfo *info,
+    ASS_FontProviderMetaData requested_font,
+    bool match_extended_family,
+    unsigned bold, unsigned italic,
+    uint32_t code, bool *name_match,
+    unsigned *best_font_score);
+
+/**
  * \brief Free font provider and associated fonts.
  * \param provider the font provider
  *

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -105,11 +105,21 @@ typedef void    (*DestroyProviderFunc)(void *priv);
  * \param lib ASS_Library instance
  * \param provider font provider instance
  * \param name font name (as specified in script)
+ * \param match_extended_family If true, the function allows matching against
+ *                              extended family names as defined by the provider.
+ *                              This behavior is provider-dependent.
+ * \param bold The requested boldness level.
+ * \param italic The requested italic style.
+ * \param code The character that should be present in the font, can be 0.
+ * \return The font selected by the provider.
  */
-typedef void    (*MatchFontsFunc)(void *priv,
+typedef ASS_FontInfo    *(*MatchFontsFunc)(void *priv,
                                   ASS_Library *lib,
                                   ASS_FontProvider *provider,
-                                  char *name);
+                                  char *name,
+                                  bool match_extended_family,
+                                  unsigned bold, unsigned italic,
+                                  uint32_t code);
 
 /**
  * Substitute font name by another. This implements generic font family

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -155,14 +155,19 @@ typedef void    (*SubstituteFontFunc)(void *priv, const char *name,
  *
  * \param priv font provider private data
  * \param lib ASS_Library instance
+ * \param provider font provider instance
  * \param family original font family name (try matching a similar font) (never NULL)
+ * \param bold The requested boldness level.
+ * \param italic The requested italic style.
  * \param codepoint Unicode codepoint (UTF-32)
- * \return output extended font family, allocated with malloc(), must be freed
- *         by caller.
+ * \return The font selected by the provider.
  */
-typedef char   *(*GetFallbackFunc)(void *priv,
+typedef ASS_FontInfo   *(*GetFallbackFunc)(void *priv,
                                    ASS_Library *lib,
+                                   ASS_FontProvider *provider,
                                    const char *family,
+                                   unsigned bold,
+                                   unsigned italic,
                                    uint32_t codepoint);
 
 typedef struct font_provider_funcs {

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -272,18 +272,28 @@ ass_create_font_provider(ASS_Renderer *priv, ASS_FontProviderFuncs *funcs,
 /**
  * \brief Add a font to a font provider.
  * \param provider the font provider
- * \param meta font metadata. See struct definition for more information.
+ * \param info The font to add to the database.
+ * \note After calling this function, **do not** call `ass_font_provider_free_fontinfo`
+ *       on the `info` parameter, as its contents have been copied.
+ */
+void
+ass_font_provider_add_font(ASS_FontProvider *provider,
+                           ASS_FontInfo* info);
+
+/**
+ * \brief Get the font info from a provider's font.
+ * \param provider the font provider
+ * \param meta the font metadata. See struct definition for more information.
  * \param path absolute path to font, or NULL for memory-based fonts
  * \param index index inside a font collection file
  *              (-1 to look up by PostScript name)
  * \param data private data for font callbacks
- * \return success
- *
+ * \return A pointer to an ASS_FontInfo corresponding to the given parameters.
  */
-bool
-ass_font_provider_add_font(ASS_FontProvider *provider,
-                           ASS_FontProviderMetaData *meta, const char *path,
-                           int index, void *data);
+ASS_FontInfo *
+ass_font_provider_get_font_info(ASS_FontProvider *provider,
+                                ASS_FontProviderMetaData *meta, const char *path,
+                                int index, void *data);
 
 /**
  * \brief Free font provider and associated fonts.

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -283,12 +283,14 @@ ass_create_font_provider(ASS_Renderer *priv, ASS_FontProviderFuncs *funcs,
  * \brief Add a font to a font provider.
  * \param provider the font provider
  * \param info The font to add to the database.
+ * \param is_embedded If true, the font will be added to the embedded db.
+ *                    If false, it will be added to the provider db.
  * \note After calling this function, **do not** call `ass_font_provider_free_fontinfo`
  *       on the `info` parameter, as its contents have been copied.
  */
 void
 ass_font_provider_add_font(ASS_FontProvider *provider,
-                           ASS_FontInfo* info);
+                           ASS_FontInfo* info, bool is_embedded);
 
 /**
  * \brief Get the font info from a provider's font.


### PR DESCRIPTION
The big problem with this solution is that each time we request a fallback_font, the font (even if we have previously requested it) gets added to the provider database.

As a result, we could end up with the exact same font duplicated 100 times in the database.

Currently, I don't see to properly implement this.
Note that we need to return ASS_FontInfo* because, for the android provider, we can't get the font family.
